### PR TITLE
Fix issue where tests would fail if public DNS settings are not set

### DIFF
--- a/libraries/azure_virtual_machine.rb
+++ b/libraries/azure_virtual_machine.rb
@@ -308,9 +308,14 @@ class AzureVm < Inspec.resource(1)
       # Interrogate Azure for the NIC details
       public_ip = helpers.network_mgmt.client.public_ipaddresses.get(public_ip_resource_group_name, public_ip_name)
 
-      # update the config with the information about the public IP
-      config['public_ipaddress']['domain_name_label'] = public_ip.dns_settings.domain_name_label
-      config['public_ipaddress']['dns_fqdn'] = public_ip.dns_settings.fqdn
+      # update the config with the information about the public IP if public dns settings are available
+      if !public_ip.dns_settings.nil?
+        config['public_ipaddress']['domain_name_label'] = public_ip.dns_settings.domain_name_label
+        config['public_ipaddress']['dns_fqdn'] = public_ip.dns_settings.fqdn
+      else
+        config['public_ipaddress']['domain_name_label'] = nil
+        config['public_ipaddress']['dns_fqdn'] = nil
+      end
     end
 
     # return object


### PR DESCRIPTION
Signed-off-by: Seth Thoenen (seththoenen@gmail.com)

This fixes an issue where InSpec tests would fail with the `azure_virtual_machine` resource when a VM's dns settings aren't available or set. By default, Windows virtual machines don't have the `DNS name` set in the Azure portal. This change will allow InSpec tests to execute properly if DNS settings haven't been set yet or are set to DHCP.