### PR TITLE
Using valid azure sdk arm version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'inifile'
-gem 'azure_mgmt_compute'
-gem 'azure_mgmt_resources'
-gem 'azure_mgmt_network'
+gem 'azure_mgmt_compute', "0.10.0"
+gem 'azure_mgmt_resources', "0.10.0"
+gem 'azure_mgmt_network', "0.10.0"
 gem 'bundle'
 
 group :development do


### PR DESCRIPTION
Pinning Gem versions to use v0.10.0 of azure sdk ARM until inspec azure
libraries are refactored to use newer methods introduced in v0.11.0 (WIP)
i.e. list_resources_as_lazy seems to be deprecated in v0.11.0

Signed-off-by: sanabriad <sanabria.d@gmail.com>