### PR TITLE
Using newer arm sdk version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'inifile'
-gem 'azure_mgmt_compute'
-gem 'azure_mgmt_resources'
-gem 'azure_mgmt_network'
+gem 'azure_mgmt_compute', '~> 0.11.0'
+gem 'azure_mgmt_resources', '~> 0.11.0'
+gem 'azure_mgmt_network', '~> 0.11.0'
 gem 'bundle'
 
 group :development do

--- a/libraries/azure_backend.rb
+++ b/libraries/azure_backend.rb
@@ -196,7 +196,7 @@ class ResourceManagement
   #
   # @return [Azure::ARM::Resources::Models::ResourceListResult] Object containing array of all the resources
   def get_resources(name)
-    client.resource_groups.list_resources_as_lazy(name) if exists(name)
+    client.resources.list_by_resource_group_as_lazy(name) if exists(name)
   end
 end
 


### PR DESCRIPTION
Some object methods have been deprecated in v0.11.0 of the arm sdks.
This commit fixes the get_resources method by using the new resources
object instance method. We are also updating the Gemfile accordingly.

Signed-off-by: sanabriad <sanabria.d@gmail.com>