### PR TITLE
Modified to handle adding a suffix to the end of the Public IP Address domain name

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,10 +45,13 @@ namespace :test do
     sa_name = (0...15).map { (65 + rand(26)).chr }.join.downcase
     admin_password = Passgen::generate(length: 12, uppercase: true, lowercase: true, symbols: true, digits: true)
 
+    # Use the first 4 characters of the storage account to create a suffix
+    suffix = sa_name[0..3]
+
     puts "----> Setup"
 
     # Create the plan that can be applied to Azure
-    cmd = format("cd %s/build/ && terraform plan -var 'subscription_id=%s' -var 'client_id=%s' -var 'client_secret=%s' -var 'tenant_id=%s' -var='storage_account_name=%s' -var='admin_password=%s' -out inspec-azure.plan", integration_dir, creds[:subscription_id], creds[:client_id], creds[:client_secret], creds[:tenant_id], sa_name, admin_password)
+    cmd = format("cd %s/build/ && terraform plan -var 'subscription_id=%s' -var 'client_id=%s' -var 'client_secret=%s' -var 'tenant_id=%s' -var 'storage_account_name=%s' -var 'admin_password=%s' -var 'suffix=%s' -out inspec-azure.plan", integration_dir, creds[:subscription_id], creds[:client_id], creds[:client_secret], creds[:tenant_id], sa_name, admin_password, suffix)
     sh(cmd)
 
     # Apply the plan on Azure
@@ -69,7 +72,7 @@ namespace :test do
     creds = azure_backend.spn
 
     puts "----> Cleanup"
-    cmd = format("cd %s/build/ && terraform destroy -force -var 'subscription_id=%s' -var 'client_id=%s' -var 'client_secret=%s' -var 'tenant_id=%s' -var='admin_password=dummy' -var='storage_account_name=dummy'", integration_dir, creds[:subscription_id], creds[:client_id], creds[:client_secret], creds[:tenant_id])
+    cmd = format("cd %s/build/ && terraform destroy -force -var 'subscription_id=%s' -var 'client_id=%s' -var 'client_secret=%s' -var 'tenant_id=%s' -var 'admin_password=dummy' -var 'storage_account_name=dummy' -var 'suffix=dummy'", integration_dir, creds[:subscription_id], creds[:client_id], creds[:client_secret], creds[:tenant_id])
     sh(cmd)
 
   end

--- a/test/integration/build/azure.tf
+++ b/test/integration/build/azure.tf
@@ -7,6 +7,10 @@ variable "client_id" {}
 variable "client_secret" {}
 variable "tenant_id" {}
 
+# Set a unique string which will be appended to public facing items
+# to ensure there are no clashes
+variable "suffix" {}
+
 variable "location" {
   default = "West Europe"
 }
@@ -47,7 +51,7 @@ resource "azurerm_public_ip" "public_ip_1" {
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.rg.name}"
   public_ip_address_allocation = "dynamic"
-  domain_name_label            = "linux-external-1"
+  domain_name_label            = "linux-external-1-${var.suffix}"
 }
 
 # Create the virtual network for the machines

--- a/test/integration/verify/controls/vm.rb
+++ b/test/integration/verify/controls/vm.rb
@@ -32,6 +32,6 @@ control 'azure-vm-external-1.0' do
 
   describe azure_virtual_machine(name: 'Linux-External-VM', resource_group: 'Inspec-Azure') do
     it { should have_public_ipaddress }
-    its('domain_name_label') { should eq 'linux-external-1' }
+    its('domain_name_label') { should include 'linux-external-1' }
   end
 end


### PR DESCRIPTION
The Terraform template has been updated to accept a `suffix` variable. This is appended to the end of the domain name for the public IP address.

By doing this it reduces the chances of there being a clash with another resource in the location in Azure.

The Rakefile creates this suffix, which is the first 4 characters of the storage account name.

Fixes #52

Signed-off-by: Russell Seymour <russell.seymour@turtlesystems.co.uk>

/cc @adamleff  @chris-rock 